### PR TITLE
Add include for dtostrf for Due

### DIFF
--- a/examples/bme280_test/bme280_test.ino
+++ b/examples/bme280_test/bme280_test.ino
@@ -38,7 +38,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 // Written originally by Embedded Adventures
 
 #include <BME280_MOD-1022.h>
-
+#include "avr/dtostrf.h"
 #include <Wire.h>
 
 // Arduino needs this to pring pretty numbers


### PR DESCRIPTION
By simply adding this include, this example 
works as-is with no other modifications on Due.
Tested in Arduino IDE 1.8.2 on Due